### PR TITLE
Provide unit ID to read_input_registers and fix typo

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -388,7 +388,7 @@ class BasePlugin:
         valP = decoder.decode_32bit_int()
         UpdateDevice(53,0,"{}".format(valP))
 
-        # Remote Contlor Mode
+        # Remote Control Mode
         decoder.reset()
         decoder.skip_bytes(0x0100 * 2)
         val = decoder.decode_16bit_uint()
@@ -441,7 +441,7 @@ class BasePlugin:
                 else:
                     break
             try:
-                result = client.read_input_registers((start + cycle * step), step2)
+                result = client.read_input_registers((start + cycle * step), step2, self.unit_id)
                 registers = registers + result.registers
             except:
                 Domoticz.Debug(result) 


### PR DESCRIPTION
Fixes issue https://github.com/saidlm/Domoticz-Solax-plugin/issues/8. The read_input_registers pymodbus function requires the ID of the unit to work properly. This is evident only when using RS485 devices such as the waveshare RS485 to RJ45 Ethernet Module. With the solax wifi dongle there is no `Modbus Error: [Input/Output] Modbus Error: [Invalid Message] No response received, expected at least 8 bytes (0 received)`